### PR TITLE
Updated links to conform to the HAL format by removing array structure in json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,8 @@ application/vnd.error+json
         "logref": 42,
         "message": "Validation failed",
         "_links": {
-            "help": [
-                { "href":  "http://...", "title": "Error information" }
-            ],
-            "describes": [
-                { "href":  "http://...", "title": "Error description" }
-            ]
+            "help": { "href":  "http://...", "title": "Error information" },
+            "describes": { "href":  "http://...", "title": "Error description" }
         }
     }
 ]


### PR DESCRIPTION
Removing the array structure for vnd.error+json to better match the current format of HAL
