### PR TITLE
adding draft idea for an edn representation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ application/vnd.error+json
 ]
 ```
 
+application/vnd.error+edn
+```edn
+[
+  {
+    :logref 42
+    :message "Validation failed"
+    :links {
+      :help {
+        :href "http://..."
+        :title "Error information"
+      }
+      :describes {
+        :href "http://..."
+        :title "Error description"
+      }
+    }
+  }
+]
+```
+
 ## Components
 
 vnd.error provides hypertext capabilities via two elements.


### PR DESCRIPTION
I have found myself working on a clojure application that needs something like vnd.error for safe communication between the web services.  In the clojure world, edn is a common formating for data interchange.  In short, you can think 'javascript is to json as cojure/clojurescript is to edn':

https://github.com/edn-format/edn

This is a simple conversion of the json example into edn.  Eventually, I could see the edn example evolving to use things like #tags on the urls to denote their type, but that would be overkill at this point.

Are you willing to consider this pullup request, making the edn representation something more 'official' to the concept you're promoting?

Thanks.
